### PR TITLE
Allow mixed case competency identifiers

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -271,10 +271,9 @@ export const actionHandlers = {
         let code = rawCode;
         if (!code) {
             code = 'CE';
-        } else if (!code.toUpperCase().startsWith('CE')) {
+        } else if (!code.toLowerCase().startsWith('ce')) {
             code = `CE${code}`;
         }
-        code = code.toUpperCase();
 
         const newCompetency = {
             id: crypto.randomUUID(),
@@ -319,10 +318,10 @@ export const actionHandlers = {
         if (!value) {
             competency.code = '';
         } else {
-            if (!value.toUpperCase().startsWith('CE')) {
+            if (!value.toLowerCase().startsWith('ce')) {
                 value = `CE${value}`;
             }
-            competency.code = value.toUpperCase();
+            competency.code = value;
         }
         saveState();
     },
@@ -389,10 +388,10 @@ export const actionHandlers = {
         if (!value) {
             criterion.code = '';
         } else {
-            if (!value.toUpperCase().startsWith('CA')) {
+            if (!value.toLowerCase().startsWith('ca')) {
                 value = `CA${value}`;
             }
-            criterion.code = value.toUpperCase();
+            criterion.code = value;
         }
         saveState();
     },


### PR DESCRIPTION
## Summary
- stop forcing competency and criterion codes to uppercase so their original casing is preserved
- keep prefix validation while allowing lowercase and mixed-case identifiers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a248060c8324aa71317babdbc35d