### PR TITLE
Add modal workflow for assigning activity criteria

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -278,6 +278,8 @@ export const actionHandlers = {
         }
 
         state.learningActivityGuideVisible = false;
+        state.learningActivityCriteriaModalOpen = false;
+        state.pendingCompetencyHighlightId = null;
         state.activeView = 'learningActivityEditor';
     },
     'open-learning-activity-quick': () => {
@@ -299,11 +301,15 @@ export const actionHandlers = {
         };
 
         state.learningActivityGuideVisible = false;
+        state.learningActivityCriteriaModalOpen = false;
+        state.pendingCompetencyHighlightId = null;
         state.activeView = 'learningActivityEditor';
     },
     'back-to-activities': () => {
         state.learningActivityDraft = null;
         state.learningActivityGuideVisible = false;
+        state.learningActivityCriteriaModalOpen = false;
+        state.pendingCompetencyHighlightId = null;
         state.activeView = 'activities';
     },
     'update-learning-activity-title': (id, element) => {
@@ -334,6 +340,21 @@ export const actionHandlers = {
         } else if (existingIndex !== -1) {
             state.learningActivityDraft.criteriaRefs.splice(existingIndex, 1);
         }
+    },
+    'open-learning-activity-criteria': () => {
+        state.learningActivityCriteriaModalOpen = true;
+    },
+    'close-learning-activity-criteria': () => {
+        state.learningActivityCriteriaModalOpen = false;
+    },
+    'go-to-competency-settings': (id, element) => {
+        const classId = element?.dataset?.classId;
+        state.learningActivityCriteriaModalOpen = false;
+        if (classId) {
+            state.pendingCompetencyHighlightId = classId;
+        }
+        state.activeView = 'settings';
+        state.settingsActiveTab = 'competencies';
     },
     'toggle-competency-guide': () => {
         state.learningActivityGuideVisible = !state.learningActivityGuideVisible;

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -122,6 +122,7 @@
   "activities_selected_criteria_label": "Criteris assignats",
   "activities_selected_criteria_help": "Selecciona els criteris d'avaluació que treballaràs amb aquesta activitat.",
   "activities_selected_count_label": "criteris seleccionats",
+  "activities_go_to_competency_settings": "Configuració de competències",
   "activities_no_criteria_selected": "Encara no hi ha criteris assignats a l'activitat.",
   "activities_show_guide": "Mostra la guia de competències",
   "activities_hide_guide": "Amaga la guia de competències",

--- a/locales/en.json
+++ b/locales/en.json
@@ -122,6 +122,7 @@
   "activities_selected_criteria_label": "Assigned criteria",
   "activities_selected_criteria_help": "Select the assessment criteria that this activity will address.",
   "activities_selected_count_label": "criteria selected",
+  "activities_go_to_competency_settings": "Competency settings",
   "activities_no_criteria_selected": "No criteria have been assigned to the activity yet.",
   "activities_show_guide": "Show competencies guide",
   "activities_hide_guide": "Hide competencies guide",

--- a/locales/es.json
+++ b/locales/es.json
@@ -122,6 +122,7 @@
   "activities_selected_criteria_label": "Criterios asignados",
   "activities_selected_criteria_help": "Selecciona los criterios de evaluación que trabajarás con esta actividad.",
   "activities_selected_count_label": "criterios seleccionados",
+  "activities_go_to_competency_settings": "Configuración de competencias",
   "activities_no_criteria_selected": "Todavía no hay criterios asignados a la actividad.",
   "activities_show_guide": "Mostrar guía de competencias",
   "activities_hide_guide": "Ocultar guía de competencias",

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -122,6 +122,7 @@
   "activities_selected_criteria_label": "Esleitutako irizpideak",
   "activities_selected_criteria_help": "Jarduera honen bidez landuko diren ebaluazio-irizpideak hautatu.",
   "activities_selected_count_label": "hautatutako irizpideak",
+  "activities_go_to_competency_settings": "Konpetentzien konfigurazioa",
   "activities_no_criteria_selected": "Oraindik ez da jarduerari irizpiderik esleitu.",
   "activities_show_guide": "Kompetentzien gida erakutsi",
   "activities_hide_guide": "Kompetentzien gida ezkutatu",

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -122,6 +122,7 @@
   "activities_selected_criteria_label": "Criterios asignados",
   "activities_selected_criteria_help": "Selecciona os criterios de avaliación que se traballarán con esta actividade.",
   "activities_selected_count_label": "criterios seleccionados",
+  "activities_go_to_competency_settings": "Configuración de competencias",
   "activities_no_criteria_selected": "Aínda non hai criterios asignados á actividade.",
   "activities_show_guide": "Amosar a guía de competencias",
   "activities_hide_guide": "Agochar a guía de competencias",

--- a/main.js
+++ b/main.js
@@ -30,10 +30,26 @@ function render() {
         default: viewContent = views.renderScheduleView();
     }
     mainContent.innerHTML = `<div class="animate-fade-in">${viewContent}</div>`;
-    
+
     updateMobileHeader();
     lucide.createIcons();
     attachEventListeners();
+
+    if (state.activeView === 'settings' && state.pendingCompetencyHighlightId) {
+        const targetId = state.pendingCompetencyHighlightId;
+        requestAnimationFrame(() => {
+            const card = document.getElementById(`competency-card-${targetId}`);
+            if (card) {
+                card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                card.style.transition = 'outline 0.1s ease-in-out';
+                card.style.outline = '3px solid #3b82f6';
+                setTimeout(() => {
+                    card.style.outline = 'none';
+                }, 1500);
+            }
+            state.pendingCompetencyHighlightId = null;
+        });
+    }
 }
 
 function updateMobileHeader() {
@@ -89,7 +105,8 @@ function handleAction(action, element, event) {
         'add-positive-record', 'add-incident-record', 'set-student-timeline-filter',
         'open-learning-activity-editor', 'open-learning-activity-quick', 'back-to-activities',
         'save-learning-activity-draft', 'toggle-learning-activity-list', 'toggle-competency-guide',
-        'toggle-learning-activity-criterion'
+        'toggle-learning-activity-criterion', 'open-learning-activity-criteria',
+        'close-learning-activity-criteria', 'go-to-competency-settings'
     ];
 
     if (actionHandlers[action]) {

--- a/state.js
+++ b/state.js
@@ -28,6 +28,8 @@ export const state = {
     learningActivityDraft: null,
     expandedLearningActivityClassIds: [],
     learningActivityGuideVisible: false,
+    learningActivityCriteriaModalOpen: false,
+    pendingCompetencyHighlightId: null,
 };
 
 export function getRandomPastelColor() {
@@ -110,4 +112,6 @@ export function loadState() {
     state.learningActivityDraft = null;
     state.expandedLearningActivityClassIds = [];
     state.learningActivityGuideVisible = false;
+    state.learningActivityCriteriaModalOpen = false;
+    state.pendingCompetencyHighlightId = null;
 }

--- a/views.js
+++ b/views.js
@@ -336,9 +336,9 @@ export function renderActivitiesView() {
 
         const activitiesHtml = visibleActivities.map(activity => {
             const assignedCount = Array.isArray(activity.criteriaRefs) ? activity.criteriaRefs.length : 0;
-            const assignedLabel = assignedCount > 0
+            const assignedLabelContent = assignedCount > 0
                 ? `${assignedCount} ${t('activities_assigned_criteria_label')}`
-                : t('activities_assigned_criteria_none');
+                : `<span class="inline-flex items-center gap-1"><i data-lucide="crosshair" class="w-3 h-3"></i>${t('activities_assigned_criteria_none')}</span>`;
             const createdDate = formatDateForDisplay(activity.createdAt);
             const description = activity.description?.trim();
             return `
@@ -350,7 +350,7 @@ export function renderActivitiesView() {
                 >
                     <div class="flex items-start justify-between gap-3">
                         <span class="font-semibold text-gray-800 dark:text-gray-100">${activity.title?.trim() || t('activities_untitled_label')}</span>
-                        <span class="text-xs text-blue-600 dark:text-blue-400">${assignedLabel}</span>
+                        <span class="text-xs text-blue-600 dark:text-blue-400">${assignedLabelContent}</span>
                     </div>
                     <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">${description || t('activities_no_description')}</p>
                     ${createdDate ? `<div class="mt-3 text-xs text-gray-500 dark:text-gray-400 flex items-center gap-2"><i data-lucide="calendar" class="w-4 h-4"></i><span>${t('activities_created_on')} ${createdDate}</span></div>` : ''}
@@ -549,6 +549,32 @@ export function renderLearningActivityEditorView() {
         : `<p class="text-sm text-gray-500 dark:text-gray-400">${t('activities_no_competencies_help')}</p>`;
 
     const selectedCount = selectedCriteria.length;
+    const isCriteriaModalOpen = state.learningActivityCriteriaModalOpen;
+    const criteriaModalHtml = !isCriteriaModalOpen ? '' : `
+        <div class="fixed inset-0 z-40 flex items-center justify-center px-4 py-6">
+            <div class="absolute inset-0 bg-gray-900/50 dark:bg-gray-900/70" data-action="close-learning-activity-criteria"></div>
+            <div class="relative max-w-3xl w-full bg-white dark:bg-gray-900 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 p-6">
+                <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                    <div>
+                        <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">${t('activities_available_criteria_title')}</h3>
+                        <p class="text-sm text-gray-500 dark:text-gray-400">${t('activities_selected_criteria_help')}</p>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <button type="button" data-action="go-to-competency-settings" data-class-id="${targetClass.id}" class="inline-flex items-center gap-2 px-3 py-2 text-sm bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-200 rounded-md border border-blue-200 dark:border-blue-700 hover:bg-blue-100 dark:hover:bg-blue-900/40">
+                            <i data-lucide="target" class="w-4 h-4"></i>
+                            <span>${t('activities_go_to_competency_settings')}</span>
+                        </button>
+                        <button type="button" data-action="close-learning-activity-criteria" class="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800">
+                            <i data-lucide="x" class="w-5 h-5"></i>
+                        </button>
+                    </div>
+                </div>
+                <div class="mt-4 space-y-4 max-h-[70vh] overflow-y-auto pr-2">
+                    ${availableCriteriaHtml}
+                </div>
+            </div>
+        </div>
+    `;
 
     return `
         <div class="p-4 sm:p-6 bg-gray-50 dark:bg-gray-900/50 min-h-full">
@@ -588,7 +614,10 @@ export function renderLearningActivityEditorView() {
                                 <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">${t('activities_selected_criteria_label')}</h3>
                                 <p class="text-sm text-gray-500 dark:text-gray-400">${t('activities_selected_criteria_help')}</p>
                             </div>
-                            <span class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-sm bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-200 border border-blue-200 dark:border-blue-700">${selectedCount} ${t('activities_selected_count_label')}</span>
+                            <button type="button" data-action="open-learning-activity-criteria" class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-sm bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-200 border border-blue-200 dark:border-blue-700 hover:bg-blue-100 dark:hover:bg-blue-900/40 focus:outline-none focus:ring-2 focus:ring-blue-400/60">
+                                <i data-lucide="list-checks" class="w-4 h-4"></i>
+                                <span><span class="font-semibold">${selectedCount}</span> ${t('activities_selected_count_label')}</span>
+                            </button>
                         </div>
                         ${selectedCriteriaHtml}
                         <button data-action="toggle-competency-guide" class="inline-flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 hover:underline">
@@ -598,13 +627,10 @@ export function renderLearningActivityEditorView() {
                         ${competencyGuideHtml}
                     </div>
 
-                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 space-y-4">
-                        <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">${t('activities_available_criteria_title')}</h3>
-                        ${availableCriteriaHtml}
-                    </div>
                 </div>
             </div>
         </div>
+        ${criteriaModalHtml}
     `;
 }
 


### PR DESCRIPTION
## Summary
- show the Lucide crosshair icon when an activity has no assigned criteria in the activities view
- move assessment criteria selection into a popup opened from the selected-count pill and add a shortcut to competency settings
- track UI state for the new modal/highlight behaviour and localise the new link label across supported languages

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2b73e6e4483249b801960334fb2ff