### PR TITLE
Simplify competency creation in settings view

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -64,6 +64,66 @@ function getNextCriterionCode(competency) {
     return `CA${nextIndex}`;
 }
 
+function getNextCompetencyCode(activity) {
+    const competencies = Array.isArray(activity?.competencies) ? activity.competencies : [];
+
+    let defaultPrefix = '';
+    let maxNumber = 0;
+    let maxDigits = 2;
+
+    competencies.forEach(competency => {
+        const code = competency?.code;
+        if (typeof code !== 'string') {
+            return;
+        }
+
+        const trimmed = code.trim();
+        if (!trimmed) {
+            return;
+        }
+
+        const baseIdentifier = getCompetencyBaseIdentifier(trimmed);
+        if (baseIdentifier) {
+            const match = baseIdentifier.match(/^(.*?)(\d+)$/);
+            if (match) {
+                const [, prefix, digits] = match;
+                const value = parseInt(digits, 10);
+                if (!Number.isNaN(value)) {
+                    if (value >= maxNumber) {
+                        defaultPrefix = prefix;
+                    }
+                    maxNumber = Math.max(maxNumber, value);
+                    maxDigits = Math.max(maxDigits, digits.length);
+                    return;
+                }
+            }
+
+            if (!defaultPrefix) {
+                defaultPrefix = baseIdentifier;
+            }
+        }
+
+        const trailingDigitsMatch = trimmed.match(/^(CE.*?)(\d+)$/i);
+        if (trailingDigitsMatch) {
+            const [, prefixWithCe, digits] = trailingDigitsMatch;
+            const value = parseInt(digits, 10);
+            if (!Number.isNaN(value)) {
+                const prefix = prefixWithCe.replace(/^CE/i, '');
+                if (value >= maxNumber) {
+                    defaultPrefix = prefix;
+                }
+                maxNumber = Math.max(maxNumber, value);
+                maxDigits = Math.max(maxDigits, digits.length);
+            }
+        }
+    });
+
+    const nextNumber = (maxNumber || 0) + 1;
+    const padded = String(nextNumber).padStart(maxDigits, '0');
+    const prefix = defaultPrefix || '';
+    return `CE${prefix}${padded}`;
+}
+
 function showImportSummary(data) {
     const title = t('import_summary_title');
     const content = `
@@ -545,27 +605,10 @@ export const actionHandlers = {
         const activity = state.activities.find(a => a.id === activityId);
         if (!activity) return;
 
-        const codeInput = document.getElementById(`new-competency-code-${activityId}`);
-        const descriptionInput = document.getElementById(`new-competency-description-${activityId}`);
-
-        const rawCode = codeInput ? codeInput.value.trim() : '';
-        const description = descriptionInput ? descriptionInput.value.trim() : '';
-
-        if (!rawCode && !description) {
-            return;
-        }
-
-        let code = rawCode;
-        if (!code) {
-            code = 'CE';
-        } else if (!code.toLowerCase().startsWith('ce')) {
-            code = `CE${code}`;
-        }
-
         const newCompetency = {
             id: crypto.randomUUID(),
-            code,
-            description,
+            code: getNextCompetencyCode(activity),
+            description: '',
             criteria: []
         };
 
@@ -574,9 +617,6 @@ export const actionHandlers = {
         }
 
         activity.competencies.push(newCompetency);
-
-        if (codeInput) codeInput.value = '';
-        if (descriptionInput) descriptionInput.value = '';
 
         saveState();
     },

--- a/views.js
+++ b/views.js
@@ -1369,24 +1369,24 @@ export function renderSettingsView() {
 
         return `
             <div id="competency-card-${c.id}" class="bg-white dark:bg-gray-800 rounded-lg shadow-md flex flex-col">
-                <div class="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-t-lg">
-                    <h3 class="text-xl font-bold" style="color: ${darkenColor(c.color, 40)}">${c.name}</h3>
-                    <div class="text-sm text-gray-600 dark:text-gray-400 mt-2 flex items-center gap-2">
-                        <i data-lucide="target" class="w-4 h-4"></i>
-                        <span>${competencyCount} ${t('competencies_short_label')}</span>
+                <div class="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-t-lg flex flex-col gap-2">
+                    <div>
+                        <h3 class="text-xl font-bold" style="color: ${darkenColor(c.color, 40)}">${c.name}</h3>
+                        <div class="text-sm text-gray-600 dark:text-gray-400 mt-2 flex items-center gap-2">
+                            <i data-lucide="target" class="w-4 h-4"></i>
+                            <span>${competencyCount} ${t('competencies_short_label')}</span>
+                        </div>
+                    </div>
+                    <div class="mt-auto">
+                        <button data-action="add-competency" data-activity-id="${c.id}" class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-50 dark:focus:ring-offset-gray-800">
+                            <i data-lucide="plus" class="w-5 h-5"></i>
+                            <span class="sr-only">${t('add_competency')}</span>
+                        </button>
                     </div>
                 </div>
                 <div class="p-4 flex flex-col gap-4 flex-grow">
                     <div class="space-y-2 max-h-48 overflow-y-auto">
                         ${competenciesHtml || `<p class=\"text-sm text-gray-500 dark:text-gray-400\">${t('no_competencies_in_class')}</p>`}
-                    </div>
-                    <div class="flex flex-col gap-2 border-t border-gray-200 dark:border-gray-700 pt-4">
-                        <input type="text" id="new-competency-code-${c.id}" placeholder="${t('add_competency_identifier_placeholder')}" class="p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md">
-                        <textarea id="new-competency-description-${c.id}" placeholder="${t('add_competency_description_placeholder')}" class="p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md h-20"></textarea>
-                        <button data-action="add-competency" data-activity-id="${c.id}" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 flex items-center justify-center gap-2">
-                            <i data-lucide="plus" class="w-5 h-5"></i>
-                            ${t('add_competency')}
-                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- replace the competency creation form with a compact add button on each class card
- automatically generate sequential competency codes when creating a new competency
- keep new competencies editable through the detail view after creation

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e2bc85a83083249bc8223e6ae886f9