### PR TITLE
Adjust student annotation action icon sizing and alignment

### DIFF
--- a/views.js
+++ b/views.js
@@ -1530,7 +1530,7 @@ export function renderActivityDetailView() {
             const buttonClasses = `${basePillClass} ${isActive ? option.activeClasses : inactivePillClass}`;
             return `
                 <button type="button" data-action="toggle-attendance-status" data-student-id="${student.id}" data-status="${option.status}" class="${buttonClasses}" aria-pressed="${isActive}" title="${option.label}" aria-label="${option.label}">
-                    <i data-lucide="${option.icon}" class="w-5 h-5"></i>
+                    <i data-lucide="${option.icon}" class="w-4 h-4"></i>
                     <span class="sr-only">${option.label}</span>
                 </button>
             `;
@@ -1625,27 +1625,27 @@ export function renderActivityDetailView() {
 
         return `
             <div id="student-annotation-${student.id}" class="p-3 border border-gray-200 dark:border-gray-700 rounded-md space-y-3 bg-gray-50/60 dark:bg-gray-900/40">
-                <div class="flex flex-wrap items-center justify-between gap-3">
+                <div class="flex items-center gap-3">
                     <button data-action="select-student" data-student-id="${student.id}" class="text-left font-medium text-blue-600 dark:text-blue-400 hover:underline">
                         ${student.name}
                     </button>
-                    <div class="flex flex-wrap items-center gap-2">
-                        <div class="flex flex-wrap items-center gap-2">
+                    <div class="flex items-center gap-2 ml-auto">
+                        <div class="flex items-center gap-2">
                             ${attendanceButtons}
                         </div>
                         <div class="flex items-center gap-2 ml-2">
                             <button type="button" data-action="add-positive-record" data-student-id="${student.id}" class="${positiveButtonClasses}" title="${t('add_positive_record')}" aria-label="${t('add_positive_record')}">
-                                <i data-lucide="shield-plus" class="w-5 h-5"></i>
+                                <i data-lucide="shield-plus" class="w-4 h-4"></i>
                                 <span class="sr-only">${t('positive_record_label')}</span>
                                 ${positivesCount > 0 ? `<span class="px-1.5 py-0.5 rounded-full bg-white/70 dark:bg-green-900/60 text-xs font-semibold">${positivesCount}</span>` : ''}
                             </button>
                             <button type="button" data-action="add-comment-record" data-student-id="${student.id}" class="${commentButtonClasses}" title="${t('add_comment_record')}" aria-label="${t('add_comment_record')}">
-                                <i data-lucide="message-square-more" class="w-5 h-5"></i>
+                                <i data-lucide="message-square-more" class="w-4 h-4"></i>
                                 <span class="sr-only">${t('comment_record_label')}</span>
                                 ${commentsCount > 0 ? `<span class="px-1.5 py-0.5 rounded-full bg-white/70 dark:bg-blue-900/60 text-xs font-semibold">${commentsCount}</span>` : ''}
                             </button>
                             <button type="button" data-action="add-incident-record" data-student-id="${student.id}" class="${incidentButtonClasses}" title="${t('add_incident_record')}" aria-label="${t('add_incident_record')}">
-                                <i data-lucide="clock-alert" class="w-5 h-5"></i>
+                                <i data-lucide="clock-alert" class="w-4 h-4"></i>
                                 <span class="sr-only">${t('incident_record_label')}</span>
                                 ${incidentsCount > 0 ? `<span class="px-1.5 py-0.5 rounded-full bg-white/70 dark:bg-red-900/60 text-xs font-semibold">${incidentsCount}</span>` : ''}
                             </button>


### PR DESCRIPTION
## Summary
- shrink the action icons for student annotations to reduce visual weight
- keep attendance and action buttons aligned to the right of each student name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e35bb7f84483248c7da1f8f2349d9c