### PR TITLE
Simplify rubric level buttons and add zebra striping

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,15 @@
-body { 
-    font-family: 'Inter', sans-serif; 
+body {
+    font-family: 'Inter', sans-serif;
+}
+
+.rubric-assessment-table tbody tr:nth-child(odd) th,
+.rubric-assessment-table tbody tr:nth-child(odd) td {
+    background-color: #f9fafb;
+}
+
+html.dark .rubric-assessment-table tbody tr:nth-child(odd) th,
+html.dark .rubric-assessment-table tbody tr:nth-child(odd) td {
+    background-color: rgba(148, 163, 184, 0.12);
 }
 
 .animate-fade-in { 

--- a/views.js
+++ b/views.js
@@ -1766,9 +1766,9 @@ export function renderLearningActivityRubricView() {
                     const isActive = currentLevel === level;
                     const buttonClasses = `${baseLevelButtonClass} ${isActive ? levelStyles[level].active : levelStyles[level].inactive}`;
                     return `<td class="px-2 py-2 text-center align-top">
-                        <button type="button" data-action="set-rubric-score" data-learning-activity-id="${activity.id}" data-item-id="${item.id}" data-student-id="${student.id}" data-level="${level}" class="${buttonClasses}" aria-pressed="${isActive}" title="${escapeHtml(tooltip)}">
+                        <button type="button" data-action="set-rubric-score" data-learning-activity-id="${activity.id}" data-item-id="${item.id}" data-student-id="${student.id}" data-level="${level}" class="${buttonClasses}" aria-pressed="${isActive}" aria-label="${escapeHtml(levelLabel)}" title="${escapeHtml(tooltip)}">
                             <span class="block text-[11px] font-bold leading-none">${level}</span>
-                            <span class="block text-[10px] leading-tight">${escapeHtml(levelLabel)}</span>
+                            <span class="sr-only">${escapeHtml(levelLabel)}</span>
                         </button>
                     </td>`;
                 }).join('');
@@ -1819,7 +1819,7 @@ export function renderLearningActivityRubricView() {
     const assessmentTableHtml = assessmentRowsHtml
         ? `
             <div class="overflow-x-auto">
-                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 rubric-assessment-table">
                     <thead class="bg-white dark:bg-gray-800">
                         <tr>
                             <th scope="col" class="px-3 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 min-w-[10rem]">${t('rubric_students_column')}</th>


### PR DESCRIPTION
## Summary
- hide the verbose rubric level labels on assessment buttons while keeping tooltips and accessibility metadata
- add zebra striping to the rubric assessment table with a dark-theme friendly color override

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e3a91b78e08324b97dbfa0f119b6c5