### PR TITLE
Enable direct rubric access from evaluation activities

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -758,18 +758,23 @@ export const actionHandlers = {
         if (!activityId) return;
         const activity = state.learningActivities.find(act => act.id === activityId);
         if (!activity) return;
+        const previousView = state.activeView;
+        const openAssessmentTab = previousView === 'evaluation';
+        state.learningActivityRubricReturnView = previousView;
         syncRubricWithActivityCriteria(activity);
         saveState();
         state.activeLearningActivityRubricId = activityId;
-        state.learningActivityRubricTab = 'configuration';
+        state.learningActivityRubricTab = openAssessmentTab ? 'assessment' : 'configuration';
         state.learningActivityRubricFilter = '';
         state.activeView = 'learningActivityRubric';
     },
     'close-learning-activity-rubric': () => {
+        const returnView = state.learningActivityRubricReturnView || 'activities';
         state.activeLearningActivityRubricId = null;
         state.learningActivityRubricTab = 'configuration';
         state.learningActivityRubricFilter = '';
-        state.activeView = 'activities';
+        state.activeView = returnView;
+        state.learningActivityRubricReturnView = null;
     },
     'set-learning-activity-rubric-tab': (id, element) => {
         const tab = element?.dataset?.tab;

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -128,6 +128,7 @@
   "evaluation_status_not_started": "No iniciades",
   "evaluation_class_no_pending": "No hi ha activitats pendents en aquesta assignatura.",
   "evaluation_class_pending_count": "Activitats pendents: {{count}}",
+  "evaluation_open_activity_assessment": "Obre l'avaluació de {{title}}",
   "evaluation_grades_select_class": "Selecciona una assignatura per veure les qualificacions.",
   "evaluation_grades_no_students": "No hi ha alumnat assignat a aquesta assignatura.",
   "evaluation_grades_no_activities": "Aquesta assignatura encara no té activitats d'avaluació.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -128,6 +128,7 @@
   "evaluation_status_not_started": "Not started",
   "evaluation_class_no_pending": "There are no pending activities for this course.",
   "evaluation_class_pending_count": "Pending activities: {{count}}",
+  "evaluation_open_activity_assessment": "Open assessment for {{title}}",
   "evaluation_grades_select_class": "Select a course to view the grades.",
   "evaluation_grades_no_students": "There are no students enrolled in this course.",
   "evaluation_grades_no_activities": "This course does not have assessment activities yet.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -128,6 +128,7 @@
   "evaluation_status_not_started": "No iniciadas",
   "evaluation_class_no_pending": "No hay actividades pendientes en esta asignatura.",
   "evaluation_class_pending_count": "Actividades pendientes: {{count}}",
+  "evaluation_open_activity_assessment": "Abrir la evaluación de {{title}}",
   "evaluation_grades_select_class": "Selecciona una asignatura para ver las calificaciones.",
   "evaluation_grades_no_students": "No hay alumnado asignado a esta asignatura.",
   "evaluation_grades_no_activities": "Esta asignatura todavía no tiene actividades de evaluación.",

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -128,6 +128,7 @@
   "evaluation_status_not_started": "Hasi gabe",
   "evaluation_class_no_pending": "Ikasgai honek ez du jarduera zainik.",
   "evaluation_class_pending_count": "Zain dauden jarduerak: {{count}}",
+  "evaluation_open_activity_assessment": "Ireki {{title}}(r)en ebaluazioa",
   "evaluation_grades_select_class": "Hautatu ikasgai bat kalifikazioak ikusteko.",
   "evaluation_grades_no_students": "Ez dago ikasgai honekin lotutako ikaslerik.",
   "evaluation_grades_no_activities": "Ikasgai honek ez du ebaluazio jarduerarik oraindik.",

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -128,6 +128,7 @@
   "evaluation_status_not_started": "Non iniciadas",
   "evaluation_class_no_pending": "Non hai actividades pendentes nesta materia.",
   "evaluation_class_pending_count": "Actividades pendentes: {{count}}",
+  "evaluation_open_activity_assessment": "Abrir a avaliación de {{title}}",
   "evaluation_grades_select_class": "Selecciona unha materia para ver as cualificacións.",
   "evaluation_grades_no_students": "Non hai alumnado asignado a esta materia.",
   "evaluation_grades_no_activities": "Esta materia aínda non ten actividades de avaliación.",

--- a/state.js
+++ b/state.js
@@ -43,6 +43,7 @@ export const state = {
     learningActivityRubricFilter: '',
     evaluationActiveTab: 'activities',
     selectedEvaluationClassId: null,
+    learningActivityRubricReturnView: null,
 };
 
 function generateId(prefix = 'id') {

--- a/views.js
+++ b/views.js
@@ -638,15 +638,28 @@ function renderEvaluationActivitiesTab(classes) {
                         ? `<p class="mt-2 text-sm text-gray-600 dark:text-gray-300">${escapeHtml(activity.description)}</p>`
                         : '';
 
+                    const rawActivityTitle = activity.title?.trim() || t('activities_untitled_label');
+                    const activityTitle = escapeHtml(rawActivityTitle);
+                    const labelTemplate = t('evaluation_open_activity_assessment');
+                    const accessibleLabel = labelTemplate.startsWith('[')
+                        ? activityTitle
+                        : escapeHtml(labelTemplate.replace('{{title}}', rawActivityTitle));
+
                     return `
-                        <article class="p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-white/80 dark:bg-gray-800/70 shadow-sm">
+                        <button
+                            type="button"
+                            data-action="open-learning-activity-rubric"
+                            data-learning-activity-id="${activity.id}"
+                            class="block w-full text-left p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-white/80 dark:bg-gray-800/70 shadow-sm hover:border-blue-400 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-400/60 dark:hover:border-blue-500 dark:focus:ring-blue-500/60 transition-colors"
+                            aria-label="${accessibleLabel}"
+                        >
                             <div class="flex items-start justify-between gap-3">
-                                <h5 class="text-base font-semibold text-gray-800 dark:text-gray-100">${escapeHtml(activity.title?.trim() || t('activities_untitled_label'))}</h5>
+                                <h5 class="text-base font-semibold text-gray-800 dark:text-gray-100">${activityTitle}</h5>
                                 <span class="inline-flex items-center px-2 py-0.5 text-xs font-semibold rounded-full ${meta.badgeClasses}">${escapeHtml(meta.label)}</span>
                             </div>
                             ${descriptionHtml}
                             ${dateInfo}
-                        </article>
+                        </button>
                     `;
                 }).join('');
 


### PR DESCRIPTION
## Summary
- make pending evaluation activity cards open the linked learning activity rubric for grading
- return to the originating view after closing a rubric and switch to the assessment tab when launched from evaluation
- add locale strings supporting the new accessibility label on activity buttons

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e3e248a0ac832498c97b34cbe8bf44