### PR TITLE
Add automatic "Corrected" status for learning activities

### DIFF
--- a/locales/ca.json
+++ b/locales/ca.json
@@ -121,6 +121,7 @@
   "learning_activity_status_scheduled": "Planificada",
   "learning_activity_status_open": "Oberta a entregues",
   "learning_activity_status_pending": "Pendent de correcció",
+  "learning_activity_status_corrected": "Corregida",
   "learning_activity_status_auto": "Automàtic",
   "evaluation_view_title": "Avaluació",
   "evaluation_tab_activities": "Activitats",

--- a/locales/en.json
+++ b/locales/en.json
@@ -121,6 +121,7 @@
   "learning_activity_status_scheduled": "Planned",
   "learning_activity_status_open": "Open for submissions",
   "learning_activity_status_pending": "Pending review",
+  "learning_activity_status_corrected": "Graded",
   "learning_activity_status_auto": "Automatic",
   "evaluation_view_title": "Assessment",
   "evaluation_tab_activities": "Activities",

--- a/locales/es.json
+++ b/locales/es.json
@@ -121,6 +121,7 @@
   "learning_activity_status_scheduled": "Planificada",
   "learning_activity_status_open": "Abierta a entregas",
   "learning_activity_status_pending": "Pendiente de corrección",
+  "learning_activity_status_corrected": "Corregida",
   "learning_activity_status_auto": "Automático",
   "evaluation_view_title": "Evaluación",
   "evaluation_tab_activities": "Actividades",

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -121,6 +121,7 @@
   "learning_activity_status_scheduled": "Planifikatuta",
   "learning_activity_status_open": "Entrega irekia",
   "learning_activity_status_pending": "Zuzenketaren zain",
+  "learning_activity_status_corrected": "Zuzenduta",
   "learning_activity_status_auto": "Automatikoa",
   "evaluation_view_title": "Ebaluazioa",
   "evaluation_tab_activities": "Jarduerak",

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -121,6 +121,7 @@
   "learning_activity_status_scheduled": "Planificada",
   "learning_activity_status_open": "Aberta a entregas",
   "learning_activity_status_pending": "Pendente de corrección",
+  "learning_activity_status_corrected": "Corrixida",
   "learning_activity_status_auto": "Automático",
   "evaluation_view_title": "Avaliación",
   "evaluation_tab_activities": "Actividades",

--- a/views.js
+++ b/views.js
@@ -355,6 +355,10 @@ export function renderActivitiesView() {
             [LEARNING_ACTIVITY_STATUS.PENDING_REVIEW]: {
                 label: t('learning_activity_status_pending'),
                 classes: 'bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/40 dark:text-amber-200 dark:border-amber-700'
+            },
+            [LEARNING_ACTIVITY_STATUS.CORRECTED]: {
+                label: t('learning_activity_status_corrected'),
+                classes: 'bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/40 dark:text-emerald-200 dark:border-emerald-700'
             }
         };
 
@@ -613,6 +617,10 @@ function renderEvaluationActivitiesTab(classes) {
         [LEARNING_ACTIVITY_STATUS.SCHEDULED]: {
             label: t('evaluation_status_not_started'),
             badgeClasses: 'bg-gray-500/10 text-gray-600 border border-gray-200 dark:text-gray-300 dark:border-gray-700 dark:bg-gray-800/60'
+        },
+        [LEARNING_ACTIVITY_STATUS.CORRECTED]: {
+            label: t('learning_activity_status_corrected'),
+            badgeClasses: 'bg-emerald-500/10 text-emerald-600 border border-emerald-200 dark:text-emerald-200 dark:border-emerald-600 dark:bg-emerald-900/30'
         }
     };
 
@@ -1047,6 +1055,7 @@ export function renderLearningActivityEditorView() {
         [LEARNING_ACTIVITY_STATUS.SCHEDULED]: 'learning_activity_status_scheduled',
         [LEARNING_ACTIVITY_STATUS.OPEN_SUBMISSIONS]: 'learning_activity_status_open',
         [LEARNING_ACTIVITY_STATUS.PENDING_REVIEW]: 'learning_activity_status_pending',
+        [LEARNING_ACTIVITY_STATUS.CORRECTED]: 'learning_activity_status_corrected',
     }[automaticStatusPreview] || 'learning_activity_status_scheduled';
     const automaticStatusLabel = t(automaticStatusLabelKey);
     const statusOptions = [
@@ -1054,6 +1063,7 @@ export function renderLearningActivityEditorView() {
         { value: LEARNING_ACTIVITY_STATUS.SCHEDULED, label: t('learning_activity_status_scheduled') },
         { value: LEARNING_ACTIVITY_STATUS.OPEN_SUBMISSIONS, label: t('learning_activity_status_open') },
         { value: LEARNING_ACTIVITY_STATUS.PENDING_REVIEW, label: t('learning_activity_status_pending') },
+        { value: LEARNING_ACTIVITY_STATUS.CORRECTED, label: t('learning_activity_status_corrected') },
     ];
     const statusSelectOptions = statusOptions.map(option => `
         <option value="${option.value}" ${option.value === currentStatusValue ? 'selected' : ''}>${escapeHtml(option.label)}</option>
@@ -2160,6 +2170,10 @@ export function renderLearningActivityRubricView() {
         [LEARNING_ACTIVITY_STATUS.PENDING_REVIEW]: {
             label: t('learning_activity_status_pending'),
             classes: 'bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/40 dark:text-amber-200 dark:border-amber-700'
+        },
+        [LEARNING_ACTIVITY_STATUS.CORRECTED]: {
+            label: t('learning_activity_status_corrected'),
+            classes: 'bg-emerald-100 text-emerald-700 border-emerald-200 dark:bg-emerald-900/40 dark:text-emerald-200 dark:border-emerald-700'
         }
     };
     const status = calculateLearningActivityStatus(activity);


### PR DESCRIPTION
## Summary
- detect when every student linked to an activity has a completed rubric evaluation and automatically mark the activity as Corrected
- surface the new status in activity cards, evaluation screens, and manual status controls
- localize the Corrected label across the supported languages

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4ad414654832491c02bd7fce368d7