### PR TITLE
Ensure backups include evaluation data and settings

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -324,6 +324,7 @@ function showImportSummary(data) {
     const content = `
         <ul class="list-disc list-inside space-y-2 text-left">
             <li><strong>${t('import_summary_activities')}:</strong> ${data.activities?.length || 0}</li>
+            <li><strong>${t('import_summary_learning_activities')}:</strong> ${data.learningActivities?.length || 0}</li>
             <li><strong>${t('import_summary_students')}:</strong> ${data.students?.length || 0}</li>
             <li><strong>${t('import_summary_timeslots')}:</strong> ${data.timeSlots?.length || 0}</li>
             <li><strong>${t('import_summary_entries')}:</strong> ${Object.keys(data.classEntries || {}).length}</li>
@@ -1753,6 +1754,7 @@ export const actionHandlers = {
     'export-data': () => {
         const dataStr = JSON.stringify({
             activities: state.activities,
+            learningActivities: state.learningActivities,
             students: state.students,
             timeSlots: state.timeSlots,
             schedule: state.schedule,
@@ -1762,7 +1764,12 @@ export const actionHandlers = {
             courseEndDate: state.courseEndDate,
             terms: state.terms,
             selectedTermId: state.selectedTermId,
-            holidays: state.holidays
+            holidays: state.holidays,
+            settingsActiveTab: state.settingsActiveTab,
+            studentTimelineFilter: state.studentTimelineFilter,
+            evaluationActiveTab: state.evaluationActiveTab,
+            selectedEvaluationClassId: state.selectedEvaluationClassId,
+            evaluationSelectedTermId: state.evaluationSelectedTermId,
         }, null, 2);
         const blob = new Blob([dataStr], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
@@ -1797,6 +1804,11 @@ export const actionHandlers = {
                     state.terms = data.terms || [];
                     state.selectedTermId = data.selectedTermId || 'all';
                     state.holidays = data.holidays || [];
+                    state.settingsActiveTab = data.settingsActiveTab || 'calendar';
+                    state.studentTimelineFilter = data.studentTimelineFilter || 'all';
+                    state.evaluationActiveTab = data.evaluationActiveTab || 'activities';
+                    state.selectedEvaluationClassId = data.selectedEvaluationClassId || null;
+                    state.evaluationSelectedTermId = data.evaluationSelectedTermId || 'all';
                     state.activities.forEach(activity => {
                         if (!activity.competencies) {
                             activity.competencies = [];

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -350,6 +350,7 @@
   "quick_nav_to_class": "Navegació ràpida a classe...",
   "import_summary_title": "Resum de la importació",
   "import_summary_activities": "Accions docents",
+  "import_summary_learning_activities": "Activitats d'aprenentatge",
   "import_summary_students": "Estudiants",
   "import_summary_timeslots": "Franges horàries",
   "import_summary_entries": "Entrades d'horari",

--- a/locales/en.json
+++ b/locales/en.json
@@ -350,6 +350,7 @@
   "quick_nav_to_class": "Quick navigation to class...",
   "import_summary_title": "Import Summary",
   "import_summary_activities": "Teaching actions",
+  "import_summary_learning_activities": "Learning activities",
   "import_summary_students": "Students",
   "import_summary_timeslots": "Time Slots",
   "import_summary_entries": "Schedule Entries",

--- a/locales/es.json
+++ b/locales/es.json
@@ -350,6 +350,7 @@
   "quick_nav_to_class": "Navegación rápida a clase...",
   "import_summary_title": "Resumen de la importación",
   "import_summary_activities": "Acciones docentes",
+  "import_summary_learning_activities": "Actividades de aprendizaje",
   "import_summary_students": "Estudiantes",
   "import_summary_timeslots": "Franjas horarias",
   "import_summary_entries": "Entradas de horario",

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -349,6 +349,7 @@
   "quick_nav_to_class": "Nabigazio azkarra klasera...",
   "import_summary_title": "Inportazioaren laburpena",
   "import_summary_activities": "Irakaskuntza-ekintzak",
+  "import_summary_learning_activities": "Ikasketa jarduerak",
   "import_summary_students": "Ikasleak",
   "import_summary_timeslots": "Denbora-tarteak",
   "import_summary_entries": "Ordutegiko sarrerak",

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -350,6 +350,7 @@
   "quick_nav_to_class": "Navegación rápida a clase...",
   "import_summary_title": "Resumo da importación",
   "import_summary_activities": "Accións docentes",
+  "import_summary_learning_activities": "Actividades de aprendizaxe",
   "import_summary_students": "Estudantes",
   "import_summary_timeslots": "Franxas horarias",
   "import_summary_entries": "Entradas de horario",


### PR DESCRIPTION
## Summary
- include learning activities, evaluation preferences, and configuration flags when exporting backup data
- restore the newly exported fields on import so evaluation and configuration state is preserved
- extend the import summary to highlight the number of learning activities restored and localize the new label

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4b9e6014c8324be1923c53677d9f7