### PR TITLE
Add rubric and evaluation shortcuts to activity editor

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -829,9 +829,23 @@ export const actionHandlers = {
         state.expandedLearningActivityClassIds = expanded;
     },
 
+    'go-to-evaluation-for-learning-activity': (id, element) => {
+        const draft = state.learningActivityDraft;
+        const activityId = element?.dataset?.learningActivityId || draft?.id || null;
+        const classId = element?.dataset?.classId || draft?.classId || null;
+
+        if (classId) {
+            state.selectedEvaluationClassId = classId;
+        }
+
+        state.pendingEvaluationHighlightActivityId = activityId;
+        state.evaluationActiveTab = 'activities';
+        state.activeView = 'evaluation';
+    },
+
     // --- Rubric Actions ---
     'open-learning-activity-rubric': (id, element) => {
-        const activityId = element?.dataset?.learningActivityId;
+        const activityId = element?.dataset?.learningActivityId || state.learningActivityDraft?.id;
         if (!activityId) return;
         const activity = state.learningActivities.find(act => act.id === activityId);
         if (!activity) return;

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -140,6 +140,7 @@
   "evaluation_tooltip_criterion_comment": "Comentari del criteri",
   "evaluation_tooltip_general_comment": "Comentari general",
   "activities_rubric_button_label": "Obre la rúbrica",
+  "activities_go_to_evaluation": "Vés a l'avaluació",
   "activities_editor_header": "Editor d'activitats",
   "learning_activity_rubric_view_title": "Rúbrica",
   "activities_editor_title_new": "Nova activitat",

--- a/locales/en.json
+++ b/locales/en.json
@@ -140,6 +140,7 @@
   "evaluation_tooltip_criterion_comment": "Criterion comment",
   "evaluation_tooltip_general_comment": "General comment",
   "activities_rubric_button_label": "Open rubric",
+  "activities_go_to_evaluation": "Go to evaluation",
   "activities_editor_header": "Activity editor",
   "learning_activity_rubric_view_title": "Rubric",
   "activities_editor_title_new": "New activity",

--- a/locales/es.json
+++ b/locales/es.json
@@ -140,6 +140,7 @@
   "evaluation_tooltip_criterion_comment": "Comentario del criterio",
   "evaluation_tooltip_general_comment": "Comentario general",
   "activities_rubric_button_label": "Abrir rúbrica",
+  "activities_go_to_evaluation": "Ir a evaluación",
   "activities_editor_header": "Editor de actividades",
   "learning_activity_rubric_view_title": "Rúbrica",
   "activities_editor_title_new": "Nueva actividad",

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -140,6 +140,7 @@
   "evaluation_tooltip_criterion_comment": "Irizpidearen oharra",
   "evaluation_tooltip_general_comment": "Ohar orokorra",
   "activities_rubric_button_label": "Errubrika ireki",
+  "activities_go_to_evaluation": "Ebaluaziora joan",
   "activities_editor_header": "Jarduera editorea",
   "learning_activity_rubric_view_title": "Errubrika",
   "activities_editor_title_new": "Jarduera berria",

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -140,6 +140,7 @@
   "evaluation_tooltip_criterion_comment": "Comentario do criterio",
   "evaluation_tooltip_general_comment": "Comentario xeral",
   "activities_rubric_button_label": "Abrir rúbrica",
+  "activities_go_to_evaluation": "Ir á avaliación",
   "activities_editor_header": "Editor de actividades",
   "learning_activity_rubric_view_title": "Rúbrica",
   "activities_editor_title_new": "Nova actividade",

--- a/main.js
+++ b/main.js
@@ -37,6 +37,21 @@ function render() {
     lucide.createIcons();
     attachEventListeners();
 
+    if (state.activeView === 'evaluation' && state.pendingEvaluationHighlightActivityId) {
+        const activityId = state.pendingEvaluationHighlightActivityId;
+        requestAnimationFrame(() => {
+            const target = document.querySelector(`[data-evaluation-activity-id="${activityId}"]`);
+            if (target) {
+                target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                target.classList.add('ring-4', 'ring-blue-400/60');
+                setTimeout(() => {
+                    target.classList.remove('ring-4', 'ring-blue-400/60');
+                }, 1500);
+            }
+            state.pendingEvaluationHighlightActivityId = null;
+        });
+    }
+
     if (state.activeView === 'settings' && state.pendingCompetencyHighlightId) {
         const targetId = state.pendingCompetencyHighlightId;
         requestAnimationFrame(() => {
@@ -113,7 +128,8 @@ function handleAction(action, element, event) {
         'close-learning-activity-criteria', 'go-to-competency-settings',
         'open-learning-activity-rubric', 'close-learning-activity-rubric', 'set-learning-activity-rubric-tab',
         'add-rubric-item', 'remove-rubric-item', 'move-rubric-item', 'set-rubric-score',
-        'filter-learning-activity-rubric-students', 'set-evaluation-tab', 'select-evaluation-class'
+        'filter-learning-activity-rubric-students', 'set-evaluation-tab', 'select-evaluation-class',
+        'go-to-evaluation-for-learning-activity'
     ];
     const forceRenderActions = ['toggle-rubric-not-presented', 'toggle-rubric-delivered-late'];
     const shouldForceRender = forceRenderActions.includes(action);

--- a/state.js
+++ b/state.js
@@ -46,6 +46,7 @@ export const state = {
     selectedEvaluationClassId: null,
     evaluationSelectedTermId: 'all',
     learningActivityRubricReturnView: null,
+    pendingEvaluationHighlightActivityId: null,
 };
 
 function generateId(prefix = 'id') {

--- a/views.js
+++ b/views.js
@@ -684,6 +684,7 @@ function renderEvaluationActivitiesTab(classes) {
                             type="button"
                             data-action="open-learning-activity-rubric"
                             data-learning-activity-id="${activity.id}"
+                            data-evaluation-activity-id="${activity.id}"
                             class="block w-full text-left p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-white/80 dark:bg-gray-800/70 shadow-sm hover:border-blue-400 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-400/60 dark:hover:border-blue-500 dark:focus:ring-blue-500/60 transition-colors"
                             aria-label="${accessibleLabel}"
                         >
@@ -1024,10 +1025,16 @@ export function renderLearningActivityEditorView() {
         `;
     }
 
-    renderMobileHeaderActions([
+    const mobileActions = [
+        ...(draft.isNew ? [] : [
+            { action: 'go-to-evaluation-for-learning-activity', label: t('activities_go_to_evaluation'), icon: 'check-circle-2' },
+            { action: 'open-learning-activity-rubric', label: t('activities_rubric_button_label'), icon: 'table-properties' }
+        ]),
         { action: 'save-learning-activity-draft', label: t('activities_save_button'), icon: 'save' },
         { action: 'back-to-activities', label: t('back_to_activities'), icon: 'arrow-left' }
-    ]);
+    ];
+
+    renderMobileHeaderActions(mobileActions);
 
     const competencies = Array.isArray(targetClass.competencies) ? targetClass.competencies : [];
     const selectedRefs = Array.isArray(draft.criteriaRefs) ? draft.criteriaRefs : [];
@@ -1153,6 +1160,27 @@ export function renderLearningActivityEditorView() {
 
     const selectedCount = selectedCriteria.length;
     const isCriteriaModalOpen = state.learningActivityCriteriaModalOpen;
+    const shortcutButtonsHtml = draft.isNew ? '' : `
+        <button
+            type="button"
+            data-action="go-to-evaluation-for-learning-activity"
+            data-learning-activity-id="${draft.id}"
+            data-class-id="${targetClass.id}"
+            class="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-200 hover:bg-blue-100 dark:hover:bg-blue-900/40"
+        >
+            <i data-lucide="check-circle-2" class="w-4 h-4"></i>
+            <span>${t('activities_go_to_evaluation')}</span>
+        </button>
+        <button
+            type="button"
+            data-action="open-learning-activity-rubric"
+            data-learning-activity-id="${draft.id}"
+            class="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-200 hover:bg-blue-100 dark:hover:bg-blue-900/40"
+        >
+            <i data-lucide="table-properties" class="w-4 h-4"></i>
+            <span>${t('activities_rubric_button_label')}</span>
+        </button>
+    `;
     const criteriaModalHtml = !isCriteriaModalOpen ? '' : `
         <div class="fixed inset-0 z-40 flex items-center justify-center px-4 py-6">
             <div class="absolute inset-0 bg-gray-900/50 dark:bg-gray-900/70" data-action="close-learning-activity-criteria"></div>
@@ -1188,6 +1216,7 @@ export function renderLearningActivityEditorView() {
                         <h2 class="text-2xl font-bold text-gray-800 dark:text-gray-100 mt-1">${draft.isNew ? t('activities_editor_title_new') : t('activities_editor_title_edit')}</h2>
                     </div>
                     <div class="flex flex-wrap gap-2 justify-end">
+                        ${shortcutButtonsHtml}
                         <button data-action="back-to-activities" class="px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2">
                             <i data-lucide="arrow-left" class="w-4 h-4"></i>
                             ${t('activities_cancel_button')}


### PR DESCRIPTION
## Summary
- add evaluation and rubric shortcut buttons to the learning activity editor view (desktop and mobile)
- highlight the selected activity when jumping into the evaluation view from the editor
- localize the evaluation shortcut label across supported languages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e51dc5e8b88324887ba252a393a259