### PR TITLE
Improve evaluation navigation and add rubric edit shortcut

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -838,6 +838,22 @@ export const actionHandlers = {
             state.selectedEvaluationClassId = classId;
         }
 
+        if (activityId) {
+            const activity = state.learningActivities.find(act => act.id === activityId);
+            if (activity) {
+                const previousView = state.activeView;
+                state.learningActivityRubricReturnView = previousView;
+                syncRubricWithActivityCriteria(activity);
+                saveState();
+                state.activeLearningActivityRubricId = activityId;
+                state.learningActivityRubricTab = 'assessment';
+                state.learningActivityRubricFilter = '';
+                state.pendingEvaluationHighlightActivityId = null;
+                state.activeView = 'learningActivityRubric';
+                return;
+            }
+        }
+
         state.pendingEvaluationHighlightActivityId = activityId;
         state.evaluationActiveTab = 'activities';
         state.activeView = 'evaluation';

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -173,6 +173,7 @@
   "rubric_no_class_message": "L'assignatura vinculada a aquesta activitat ja no està disponible.",
   "rubric_tab_configuration": "Configuració",
   "rubric_tab_assessment": "Avaluació",
+  "rubric_edit_activity_button": "Edita l'activitat",
   "rubric_add_criterion_label": "Afegeix un criteri d'avaluació",
   "rubric_select_placeholder": "-- Selecciona un criteri --",
   "rubric_add_button": "Afegeix a la rúbrica",

--- a/locales/en.json
+++ b/locales/en.json
@@ -173,6 +173,7 @@
   "rubric_no_class_message": "The subject linked to this activity is no longer available.",
   "rubric_tab_configuration": "Configuration",
   "rubric_tab_assessment": "Assessment",
+  "rubric_edit_activity_button": "Edit activity",
   "rubric_add_criterion_label": "Add assessment criterion",
   "rubric_select_placeholder": "-- Select a criterion --",
   "rubric_add_button": "Add to rubric",

--- a/locales/es.json
+++ b/locales/es.json
@@ -173,6 +173,7 @@
   "rubric_no_class_message": "La asignatura vinculada a esta actividad ya no está disponible.",
   "rubric_tab_configuration": "Configuración",
   "rubric_tab_assessment": "Evaluación",
+  "rubric_edit_activity_button": "Editar actividad",
   "rubric_add_criterion_label": "Añade un criterio de evaluación",
   "rubric_select_placeholder": "-- Selecciona un criterio --",
   "rubric_add_button": "Añadir a la rúbrica",

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -173,6 +173,7 @@
   "rubric_no_class_message": "Jarduera honi lotutako ikasgaia ez dago erabilgarri.",
   "rubric_tab_configuration": "Konfigurazioa",
   "rubric_tab_assessment": "Ebaluazioa",
+  "rubric_edit_activity_button": "Editatu jarduera",
   "rubric_add_criterion_label": "Gehitu ebaluazio-irizpide bat",
   "rubric_select_placeholder": "-- Hautatu irizpide bat --",
   "rubric_add_button": "Gehitu errubrikan",

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -173,6 +173,7 @@
   "rubric_no_class_message": "A materia vinculada a esta actividade xa non está dispoñible.",
   "rubric_tab_configuration": "Configuración",
   "rubric_tab_assessment": "Avaliación",
+  "rubric_edit_activity_button": "Editar actividade",
   "rubric_add_criterion_label": "Engade un criterio de avaliación",
   "rubric_select_placeholder": "-- Selecciona un criterio --",
   "rubric_add_button": "Engadir á rúbrica",

--- a/views.js
+++ b/views.js
@@ -2221,6 +2221,13 @@ export function renderLearningActivityRubricView() {
         return `<button data-action="set-learning-activity-rubric-tab" data-tab="${tab.key}" class="${classes}" aria-pressed="${isActive}">${tab.label}</button>`;
     }).join('');
 
+    const editActivityButtonHtml = activity.classId
+        ? `<button data-action="open-learning-activity-editor" data-class-id="${activity.classId}" data-learning-activity-id="${activity.id}" class="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold rounded-md border border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-600">
+                <i data-lucide="pencil" class="w-4 h-4"></i>
+                <span>${t('rubric_edit_activity_button')}</span>
+            </button>`
+        : '';
+
     const criteriaOptions = availableCriteria.map(item => {
         const competencyCode = item.competency?.code || t('competency_without_code');
         const criterionCode = item.criterion?.code || t('criterion_without_code');
@@ -2505,7 +2512,7 @@ export function renderLearningActivityRubricView() {
                         </span>
                     </div>
                 </div>
-                <div class="flex flex-wrap items-center gap-3">${tabButtonsHtml}</div>
+                <div class="flex flex-wrap items-center gap-3">${tabButtonsHtml}${editActivityButtonHtml}</div>
                 <div class="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-800 p-4 sm:p-6">
                     ${mainContent}
                 </div>


### PR DESCRIPTION
## Summary
- ensure the "Go to evaluation" shortcut opens the selected activity directly in the rubric assessment view
- add an "Edit activity" button alongside the rubric configuration and assessment tabs with translations for every locale

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e52462f70c8324a345d6dc6b289a36