### PR TITLE
Add optional generic notes to rubric criteria

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1288,7 +1288,8 @@ export const actionHandlers = {
         competency.criteria.push({
             id: crypto.randomUUID(),
             code: getNextCriterionCode(competency),
-            description: ''
+            description: '',
+            genericNote: ''
         });
 
         saveState();
@@ -1327,6 +1328,20 @@ export const actionHandlers = {
         if (!criterion) return;
 
         criterion.description = element.value;
+        saveState();
+    },
+    'update-criterion-generic-note': (id, element) => {
+        const { activityId, competencyId, criterionId } = element.dataset;
+        const activity = state.activities.find(a => a.id === activityId);
+        if (!activity) return;
+
+        const competency = activity.competencies?.find(c => c.id === competencyId);
+        if (!competency) return;
+
+        const criterion = competency.criteria?.find(cr => cr.id === criterionId);
+        if (!criterion) return;
+
+        criterion.genericNote = element.value;
         saveState();
     },
     'delete-criterion': (id, element) => {

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -95,6 +95,8 @@
   "criterion_identifier_label": "Identificador del criteri (CA...)",
   "criterion_identifier_placeholder": "Ex: CA01",
   "criterion_description_label": "Descripció del criteri",
+  "criterion_generic_note_label": "Indicació general (opcional)",
+  "criterion_generic_note_placeholder": "Escriviu una indicació general per a aquest criteri",
   "criterion_description_placeholder": "Descriu el criteri...",
   "criterion_without_code": "Sense codi",
   "criterion_without_description": "Sense descripció",

--- a/locales/es.json
+++ b/locales/es.json
@@ -95,6 +95,8 @@
   "criterion_identifier_label": "Identificador del criterio (CA...)",
   "criterion_identifier_placeholder": "Ej: CA01",
   "criterion_description_label": "Descripción del criterio",
+  "criterion_generic_note_label": "Indicación general (opcional)",
+  "criterion_generic_note_placeholder": "Escribe una indicación general para este criterio",
   "criterion_description_placeholder": "Describe el criterio...",
   "criterion_without_code": "Sin código",
   "criterion_without_description": "Sin descripción",

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -95,6 +95,8 @@
   "criterion_identifier_label": "Identificador do criterio (CA...)",
   "criterion_identifier_placeholder": "Ex: CA01",
   "criterion_description_label": "Descrición do criterio",
+  "criterion_generic_note_label": "Indicación xeral (opcional)",
+  "criterion_generic_note_placeholder": "Escribe unha indicación xeral para este criterio",
   "criterion_description_placeholder": "Describe o criterio...",
   "criterion_without_code": "Sen código",
   "criterion_without_description": "Sen descrición",

--- a/state.js
+++ b/state.js
@@ -309,6 +309,11 @@ export function loadState() {
             if (!competency.criteria) {
                 competency.criteria = [];
             }
+            competency.criteria.forEach(criterion => {
+                if (typeof criterion.genericNote !== 'string') {
+                    criterion.genericNote = '';
+                }
+            });
         });
     });
 

--- a/views.js
+++ b/views.js
@@ -1662,13 +1662,17 @@ export function renderCompetencyDetailView() {
                 <div class="flex items-start gap-2">
                     <div class="flex-1">
                         <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">${t('criterion_identifier_label')}</label>
-                        <input type="text" value="${criterion.code || ''}" data-action="update-criterion-code" data-activity-id="${activity.id}" data-competency-id="${competency.id}" data-criterion-id="${criterion.id}" placeholder="${t('criterion_identifier_placeholder')}" class="mt-1 block w-full p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md">
+                        <input type="text" value="${escapeAttribute(criterion.code || '')}" data-action="update-criterion-code" data-activity-id="${activity.id}" data-competency-id="${competency.id}" data-criterion-id="${criterion.id}" placeholder="${t('criterion_identifier_placeholder')}" class="mt-1 block w-full p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md">
                     </div>
                     <button data-action="delete-criterion" data-activity-id="${activity.id}" data-competency-id="${competency.id}" data-criterion-id="${criterion.id}" class="text-red-500 hover:text-red-700 mt-6"><i data-lucide="trash-2" class="w-5 h-5"></i></button>
                 </div>
                 <div>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">${t('criterion_generic_note_label')}</label>
+                    <textarea data-action="update-criterion-generic-note" data-activity-id="${activity.id}" data-competency-id="${competency.id}" data-criterion-id="${criterion.id}" placeholder="${t('criterion_generic_note_placeholder')}" class="mt-1 block w-full p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md h-20">${escapeHtml(criterion.genericNote || '')}</textarea>
+                </div>
+                <div>
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">${t('criterion_description_label')}</label>
-                    <textarea data-action="update-criterion-description" data-activity-id="${activity.id}" data-competency-id="${competency.id}" data-criterion-id="${criterion.id}" placeholder="${t('criterion_description_placeholder')}" class="mt-1 block w-full p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md h-20">${criterion.description || ''}</textarea>
+                    <textarea data-action="update-criterion-description" data-activity-id="${activity.id}" data-competency-id="${competency.id}" data-criterion-id="${criterion.id}" placeholder="${t('criterion_description_placeholder')}" class="mt-1 block w-full p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md h-20">${escapeHtml(criterion.description || '')}</textarea>
                 </div>
             </div>
         `).join('')
@@ -2376,6 +2380,20 @@ export function renderLearningActivityRubricView() {
                 const competencyLabel = competency?.code || t('competency_without_code');
                 const criterionCode = criterion?.code || t('criterion_without_code');
                 const criterionDescription = criterion?.description || t('criterion_without_description');
+                const genericNote = typeof criterion?.genericNote === 'string' ? criterion.genericNote.trim() : '';
+                const badgesHtml = [
+                    `<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md border border-blue-200 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-900/30 dark:text-blue-200">${escapeHtml(competencyLabel)}</span>`,
+                    `<span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md border border-purple-200 bg-purple-50 text-purple-700 dark:border-purple-700 dark:bg-purple-900/30 dark:text-purple-200">${escapeHtml(criterionCode)}</span>`
+                ].join('');
+                const criterionInfoHtml = genericNote
+                    ? [
+                        `<div class="text-sm font-semibold text-gray-800 dark:text-gray-100">${escapeHtml(genericNote)}</div>`,
+                        `<div class="mt-2 flex flex-wrap gap-2 text-xs font-semibold">${badgesHtml}</div>`
+                    ].join('')
+                    : [
+                        `<div class="text-sm font-semibold text-gray-800 dark:text-gray-100">${escapeHtml(criterionCode)}</div>`,
+                        `<div class="text-xs text-gray-600 dark:text-gray-300">${escapeHtml(competencyLabel)}</div>`
+                    ].join('');
                 const currentLevel = scores[item.id] || '';
 
                 const scoreCells = RUBRIC_LEVELS.map(level => {
@@ -2440,8 +2458,7 @@ export function renderLearningActivityRubricView() {
                     <tr>
                         ${nameCell}
                         <td class="px-3 py-3 align-top min-w-[14rem]">
-                            <div class="text-sm font-semibold text-gray-800 dark:text-gray-100">${escapeHtml(criterionCode)}</div>
-                            <div class="text-xs text-gray-600 dark:text-gray-300">${escapeHtml(competencyLabel)}</div>
+                            ${criterionInfoHtml}
                             <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">${escapeHtml(criterionDescription)}</div>
                         </td>
                         ${scoreCells}


### PR DESCRIPTION
## Summary
- add a generic note field to rubric criteria with persistence and editing actions
- update Catalan, Spanish, and Galician locales for the new note controls
- surface the optional note in the evaluation rubric alongside adjusted CA/CE indicators

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e53bde6d788324bd6b63d647716a71