### PR TITLE
Add optional guidance for activity criteria

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1288,7 +1288,8 @@ export const actionHandlers = {
         competency.criteria.push({
             id: crypto.randomUUID(),
             code: getNextCriterionCode(competency),
-            description: ''
+            description: '',
+            guidance: ''
         });
 
         saveState();
@@ -1327,6 +1328,20 @@ export const actionHandlers = {
         if (!criterion) return;
 
         criterion.description = element.value;
+        saveState();
+    },
+    'update-criterion-guidance': (id, element) => {
+        const { activityId, competencyId, criterionId } = element.dataset;
+        const activity = state.activities.find(a => a.id === activityId);
+        if (!activity) return;
+
+        const competency = activity.competencies?.find(c => c.id === competencyId);
+        if (!competency) return;
+
+        const criterion = competency.criteria?.find(cr => cr.id === criterionId);
+        if (!criterion) return;
+
+        criterion.guidance = element.value;
         saveState();
     },
     'delete-criterion': (id, element) => {

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -96,6 +96,8 @@
   "criterion_identifier_placeholder": "Ex: CA01",
   "criterion_description_label": "Descripció del criteri",
   "criterion_description_placeholder": "Descriu el criteri...",
+  "criterion_guidance_label": "Indicació genèrica (opcional)",
+  "criterion_guidance_placeholder": "Afegeix una nota o indicació genèrica per a aquest criteri...",
   "criterion_without_code": "Sense codi",
   "criterion_without_description": "Sense descripció",
   "delete_competency": "Elimina competència",

--- a/locales/en.json
+++ b/locales/en.json
@@ -96,6 +96,8 @@
   "criterion_identifier_placeholder": "e.g. CA01",
   "criterion_description_label": "Criterion description",
   "criterion_description_placeholder": "Describe the criterion...",
+  "criterion_guidance_label": "Generic note (optional)",
+  "criterion_guidance_placeholder": "Add a general note or guidance for this criterion...",
   "criterion_without_code": "No code",
   "criterion_without_description": "No description",
   "delete_competency": "Delete competency",

--- a/locales/es.json
+++ b/locales/es.json
@@ -96,6 +96,8 @@
   "criterion_identifier_placeholder": "Ej: CA01",
   "criterion_description_label": "Descripción del criterio",
   "criterion_description_placeholder": "Describe el criterio...",
+  "criterion_guidance_label": "Indicación general (opcional)",
+  "criterion_guidance_placeholder": "Añade una nota o indicación general para este criterio...",
   "criterion_without_code": "Sin código",
   "criterion_without_description": "Sin descripción",
   "delete_competency": "Eliminar competencia",

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -96,6 +96,8 @@
   "criterion_identifier_placeholder": "Adib.: CA01",
   "criterion_description_label": "Irizpidearen deskribapena",
   "criterion_description_placeholder": "Deskribatu irizpidea...",
+  "criterion_guidance_label": "Orientazio orokorra (aukerakoa)",
+  "criterion_guidance_placeholder": "Gehitu irizpide honetarako ohar edo orientazio orokor bat...",
   "criterion_without_code": "Koderik gabe",
   "criterion_without_description": "Azalpenik gabe",
   "delete_competency": "Ezabatu gaitasuna",

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -96,6 +96,8 @@
   "criterion_identifier_placeholder": "Ex: CA01",
   "criterion_description_label": "Descrición do criterio",
   "criterion_description_placeholder": "Describe o criterio...",
+  "criterion_guidance_label": "Indicación xeral (opcional)",
+  "criterion_guidance_placeholder": "Engade unha nota ou indicación xeral para este criterio...",
   "criterion_without_code": "Sen código",
   "criterion_without_description": "Sen descrición",
   "delete_competency": "Eliminar competencia",

--- a/state.js
+++ b/state.js
@@ -309,6 +309,12 @@ export function loadState() {
             if (!competency.criteria) {
                 competency.criteria = [];
             }
+
+            competency.criteria.forEach(criterion => {
+                if (typeof criterion.guidance !== 'string') {
+                    criterion.guidance = '';
+                }
+            });
         });
     });
 

--- a/views.js
+++ b/views.js
@@ -1667,8 +1667,10 @@ export function renderCompetencyDetailView() {
                     <button data-action="delete-criterion" data-activity-id="${activity.id}" data-competency-id="${competency.id}" data-criterion-id="${criterion.id}" class="text-red-500 hover:text-red-700 mt-6"><i data-lucide="trash-2" class="w-5 h-5"></i></button>
                 </div>
                 <div>
-                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">${t('criterion_description_label')}</label>
-                    <textarea data-action="update-criterion-description" data-activity-id="${activity.id}" data-competency-id="${competency.id}" data-criterion-id="${criterion.id}" placeholder="${t('criterion_description_placeholder')}" class="mt-1 block w-full p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md h-20">${criterion.description || ''}</textarea>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">${t('criterion_description_label')}</label>
+                        <textarea data-action="update-criterion-description" data-activity-id="${activity.id}" data-competency-id="${competency.id}" data-criterion-id="${criterion.id}" placeholder="${t('criterion_description_placeholder')}" class="mt-1 block w-full p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md h-20">${criterion.description || ''}</textarea>
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">${t('criterion_guidance_label')}</label>
+                    <textarea data-action="update-criterion-guidance" data-activity-id="${activity.id}" data-competency-id="${competency.id}" data-criterion-id="${criterion.id}" placeholder="${t('criterion_guidance_placeholder')}" class="mt-1 block w-full p-2 border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 rounded-md h-20">${criterion.guidance || ''}</textarea>
                 </div>
             </div>
         `).join('')
@@ -2376,6 +2378,21 @@ export function renderLearningActivityRubricView() {
                 const competencyLabel = competency?.code || t('competency_without_code');
                 const criterionCode = criterion?.code || t('criterion_without_code');
                 const criterionDescription = criterion?.description || t('criterion_without_description');
+                const rawGuidance = typeof criterion?.guidance === 'string' ? criterion.guidance : '';
+                const criterionGuidance = rawGuidance.trim();
+                const hasGuidance = criterionGuidance.length > 0;
+                const escapedGuidance = escapeHtml(criterionGuidance).replace(/\n/g, '<br>');
+                const titleHtml = hasGuidance
+                    ? `<div class="text-sm font-semibold text-gray-800 dark:text-gray-100 whitespace-pre-line">${escapedGuidance}</div>`
+                    : `<div class="text-sm font-semibold text-gray-800 dark:text-gray-100">${escapeHtml(criterionCode)}</div>`;
+                const indicatorHtml = hasGuidance
+                    ? `<div class="mt-1 text-xs text-gray-600 dark:text-gray-300 flex flex-wrap items-center gap-1">
+                            <span>${escapeHtml(competencyLabel)}</span>
+                            <span class="text-gray-400">·</span>
+                            <span>${escapeHtml(criterionCode)}</span>
+                        </div>`
+                    : `<div class="text-xs text-gray-600 dark:text-gray-300">${escapeHtml(competencyLabel)}</div>`;
+                const descriptionHtml = `<div class="text-xs text-gray-500 dark:text-gray-400 mt-1">${escapeHtml(criterionDescription)}</div>`;
                 const currentLevel = scores[item.id] || '';
 
                 const scoreCells = RUBRIC_LEVELS.map(level => {
@@ -2440,9 +2457,9 @@ export function renderLearningActivityRubricView() {
                     <tr>
                         ${nameCell}
                         <td class="px-3 py-3 align-top min-w-[14rem]">
-                            <div class="text-sm font-semibold text-gray-800 dark:text-gray-100">${escapeHtml(criterionCode)}</div>
-                            <div class="text-xs text-gray-600 dark:text-gray-300">${escapeHtml(competencyLabel)}</div>
-                            <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">${escapeHtml(criterionDescription)}</div>
+                            ${titleHtml}
+                            ${indicatorHtml}
+                            ${descriptionHtml}
                         </td>
                         ${scoreCells}
                         ${commentCell}


### PR DESCRIPTION
## Summary
- add support for storing an optional guidance note on each activity criterion and persist it in state management
- expose the guidance text area in the competency settings UI with translations for all locales
- show the guidance note within the learning activity evaluation table, aligning competency and criterion codes when guidance is present

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e54746f1a48324aab509aa7d709f79