### PR TITLE
Make competency cards collapsible

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -829,6 +829,22 @@ export const actionHandlers = {
         state.expandedLearningActivityClassIds = expanded;
     },
 
+    'toggle-competency-list': (id, element) => {
+        const classId = element.dataset.classId;
+        if (!classId) return;
+
+        const expanded = Array.isArray(state.expandedCompetencyClassIds)
+            ? [...state.expandedCompetencyClassIds]
+            : [];
+        const index = expanded.indexOf(classId);
+        if (index === -1) {
+            expanded.push(classId);
+        } else {
+            expanded.splice(index, 1);
+        }
+        state.expandedCompetencyClassIds = expanded;
+    },
+
     'go-to-evaluation-for-learning-activity': (id, element) => {
         const draft = state.learningActivityDraft;
         const activityId = element?.dataset?.learningActivityId || draft?.id || null;
@@ -1210,6 +1226,14 @@ export const actionHandlers = {
         }
 
         activity.competencies.push(newCompetency);
+
+        const expanded = Array.isArray(state.expandedCompetencyClassIds)
+            ? [...state.expandedCompetencyClassIds]
+            : [];
+        if (!expanded.includes(activityId)) {
+            expanded.push(activityId);
+        }
+        state.expandedCompetencyClassIds = expanded;
 
         saveState();
     },

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -211,6 +211,8 @@
   "settings_tab_competencies": "Competències",
   "competencies_tab_title": "Competències per assignatura",
   "competencies_short_label": "competències",
+  "show_competency_list": "Mostra les competències",
+  "hide_competency_list": "Amaga les competències",
   "competency_without_code": "Sense identificador",
   "competency_without_description": "Sense descripció",
   "no_competencies_in_class": "No hi ha competències afegides.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -211,6 +211,8 @@
   "settings_tab_competencies": "Competencies",
   "competencies_tab_title": "Competencies by subject",
   "competencies_short_label": "competencies",
+  "show_competency_list": "Show competencies",
+  "hide_competency_list": "Hide competencies",
   "competency_without_code": "No identifier",
   "competency_without_description": "No description",
   "no_competencies_in_class": "No competencies added.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -211,6 +211,8 @@
   "settings_tab_competencies": "Competencias",
   "competencies_tab_title": "Competencias por materia",
   "competencies_short_label": "competencias",
+  "show_competency_list": "Mostrar competencias",
+  "hide_competency_list": "Ocultar competencias",
   "competency_without_code": "Sin identificador",
   "competency_without_description": "Sin descripción",
   "no_competencies_in_class": "No hay competencias añadidas.",

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -211,6 +211,8 @@
   "settings_tab_competencies": "Gaitasunak",
   "competencies_tab_title": "Gaitasunak ikasgaiaren arabera",
   "competencies_short_label": "gaitasun",
+  "show_competency_list": "Erakutsi gaitasunak",
+  "hide_competency_list": "Ezkutatu gaitasunak",
   "competency_without_code": "Identifikatzailerik gabe",
   "competency_without_description": "Deskribapenik gabe",
   "no_competencies_in_class": "Ez dago gaitasunik gehituta.",

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -211,6 +211,8 @@
   "settings_tab_competencies": "Competencias",
   "competencies_tab_title": "Competencias por materia",
   "competencies_short_label": "competencias",
+  "show_competency_list": "Mostrar as competencias",
+  "hide_competency_list": "Agochar as competencias",
   "competency_without_code": "Sen identificador",
   "competency_without_description": "Sen descrición",
   "no_competencies_in_class": "Non hai competencias engadidas.",

--- a/main.js
+++ b/main.js
@@ -124,6 +124,7 @@ function handleAction(action, element, event) {
         'add-positive-record', 'add-incident-record', 'set-student-timeline-filter',
         'open-learning-activity-editor', 'open-learning-activity-quick', 'back-to-activities',
         'save-learning-activity-draft', 'toggle-learning-activity-list', 'toggle-competency-guide',
+        'toggle-competency-list',
         'toggle-learning-activity-criterion', 'open-learning-activity-criteria',
         'close-learning-activity-criteria', 'go-to-competency-settings',
         'open-learning-activity-rubric', 'close-learning-activity-rubric', 'set-learning-activity-rubric-tab',

--- a/state.js
+++ b/state.js
@@ -36,6 +36,7 @@ export const state = {
     studentTimelineFilter: 'all',
     learningActivityDraft: null,
     expandedLearningActivityClassIds: [],
+    expandedCompetencyClassIds: [],
     learningActivityGuideVisible: false,
     learningActivityCriteriaModalOpen: false,
     pendingCompetencyHighlightId: null,
@@ -314,6 +315,7 @@ export function loadState() {
 
     state.learningActivityDraft = null;
     state.expandedLearningActivityClassIds = [];
+    state.expandedCompetencyClassIds = [];
     state.learningActivityGuideVisible = false;
     state.learningActivityCriteriaModalOpen = false;
     state.pendingCompetencyHighlightId = null;

--- a/views.js
+++ b/views.js
@@ -2050,24 +2050,43 @@ export function renderSettingsView() {
             </button>
         `).join('');
 
+        const isExpanded = Array.isArray(state.expandedCompetencyClassIds)
+            ? state.expandedCompetencyClassIds.includes(c.id)
+            : false;
+        const toggleIcon = isExpanded ? 'chevron-up' : 'chevron-down';
+        const toggleLabel = isExpanded ? t('hide_competency_list') : t('show_competency_list');
+        const listContainerClasses = isExpanded
+            ? 'p-4 flex flex-col gap-4 flex-grow'
+            : 'p-4 flex flex-col gap-4 flex-grow hidden';
+
         return `
             <div id="competency-card-${c.id}" class="bg-white dark:bg-gray-800 rounded-lg shadow-md flex flex-col">
-                <div class="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-t-lg flex flex-col gap-2">
-                    <div>
-                        <h3 class="text-xl font-bold" style="color: ${darkenColor(c.color, 40)}">${c.name}</h3>
-                        <div class="text-sm text-gray-600 dark:text-gray-400 mt-2 flex items-center gap-2">
-                            <i data-lucide="target" class="w-4 h-4"></i>
-                            <span>${competencyCount} ${t('competencies_short_label')}</span>
+                <div class="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-t-lg flex flex-col gap-3">
+                    <h3 class="text-xl font-bold" style="color: ${darkenColor(c.color, 40)}">${c.name}</h3>
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                        <div class="flex items-end gap-3 flex-wrap">
+                            <button data-action="add-competency" data-activity-id="${c.id}" class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-50 dark:focus:ring-offset-gray-800">
+                                <i data-lucide="plus" class="w-5 h-5"></i>
+                                <span class="sr-only">${t('add_competency')}</span>
+                            </button>
+                            <div class="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                                <i data-lucide="target" class="w-4 h-4"></i>
+                                <span>${competencyCount} ${t('competencies_short_label')}</span>
+                            </div>
                         </div>
-                    </div>
-                    <div class="mt-auto">
-                        <button data-action="add-competency" data-activity-id="${c.id}" class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-50 dark:focus:ring-offset-gray-800">
-                            <i data-lucide="plus" class="w-5 h-5"></i>
-                            <span class="sr-only">${t('add_competency')}</span>
+                        <button
+                            data-action="toggle-competency-list"
+                            data-class-id="${c.id}"
+                            aria-expanded="${isExpanded}"
+                            aria-controls="competency-list-${c.id}"
+                            class="inline-flex items-center gap-2 text-sm font-medium text-blue-600 dark:text-blue-300 hover:underline focus:outline-none"
+                        >
+                            <span>${toggleLabel}</span>
+                            <i data-lucide="${toggleIcon}" class="w-4 h-4"></i>
                         </button>
                     </div>
                 </div>
-                <div class="p-4 flex flex-col gap-4 flex-grow">
+                <div id="competency-list-${c.id}" class="${listContainerClasses}">
                     <div class="space-y-2 max-h-48 overflow-y-auto">
                         ${competenciesHtml || `<p class=\"text-sm text-gray-500 dark:text-gray-400\">${t('no_competencies_in_class')}</p>`}
                     </div>


### PR DESCRIPTION
## Summary
- realign the add competency button within competency cards and add a toggle to collapse or expand each list
- track expanded competency cards in state and update actions so newly created competencies expand their class automatically
- add localized strings for the new competency list toggle labels across supported languages

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e563016d548324af7f5aefe404f026