### PR TITLE
Add deletion controls to activity editor with data cleanup

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1497,8 +1497,42 @@ export const actionHandlers = {
         }
     },
     'delete-activity': (id) => {
+        const learningActivitiesToRemove = state.learningActivities
+            .filter(activity => activity.classId === id)
+            .map(activity => activity.id);
+
         showModal(t('delete_activity_confirm_title'), t('delete_activity_confirm_text'), () => {
             state.activities = state.activities.filter(a => a.id !== id);
+            state.learningActivities = state.learningActivities.filter(activity => activity.classId !== id);
+
+            Object.entries(state.schedule).forEach(([key, value]) => {
+                if (value === id) {
+                    delete state.schedule[key];
+                }
+            });
+
+            state.scheduleOverrides = state.scheduleOverrides.filter(override => override.activityId !== id);
+
+            Object.keys(state.classEntries).forEach(entryId => {
+                if (entryId.startsWith(`${id}_`)) {
+                    delete state.classEntries[entryId];
+                }
+            });
+
+            state.selectedEvaluationClassId = state.selectedEvaluationClassId === id ? null : state.selectedEvaluationClassId;
+            state.selectedActivity = state.selectedActivity?.id === id ? null : state.selectedActivity;
+            state.editingActivityId = state.editingActivityId === id ? null : state.editingActivityId;
+            state.pendingCompetencyHighlightId = state.pendingCompetencyHighlightId === id ? null : state.pendingCompetencyHighlightId;
+            state.expandedLearningActivityClassIds = state.expandedLearningActivityClassIds.filter(classId => classId !== id);
+            state.expandedCompetencyClassIds = state.expandedCompetencyClassIds.filter(classId => classId !== id);
+            if (state.learningActivityDraft?.classId === id) {
+                state.learningActivityDraft = null;
+            }
+
+            if (learningActivitiesToRemove.includes(state.pendingEvaluationHighlightActivityId)) {
+                state.pendingEvaluationHighlightActivityId = null;
+            }
+
             saveState();
             document.dispatchEvent(new CustomEvent('render'));
         });

--- a/locales/ca.json
+++ b/locales/ca.json
@@ -260,7 +260,7 @@
   "class": "Classe",
   "general": "General",
   "delete_activity_confirm_title": "Confirma l'Eliminació",
-  "delete_activity_confirm_text": "Estàs segur que vols eliminar aquesta acció docent?",
+  "delete_activity_confirm_text": "Estàs segur que vols eliminar aquesta acció docent? Aquesta acció també eliminarà totes les notes de l'alumnat associades.",
   "import_students_alert": "Selecciona una classe i enganxa la llista de l'alumnat.",
   "generate_schedule_alert": "Si us plau, omple l'hora d'inici, fi i la durada de la classe.",
   "add_override_alert": "Si us plau, completa tots els camps de la substitució.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -260,7 +260,7 @@
   "class": "Class",
   "general": "General",
   "delete_activity_confirm_title": "Confirm Deletion",
-  "delete_activity_confirm_text": "Are you sure you want to delete this teaching action?",
+  "delete_activity_confirm_text": "Are you sure you want to delete this teaching action? This will also remove all associated student grades and notes.",
   "import_students_alert": "Please select a class and paste the student list.",
   "generate_schedule_alert": "Please fill in the start time, end time, and class duration.",
   "add_override_alert": "Please complete all fields for the override.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -260,7 +260,7 @@
   "class": "Clase",
   "general": "General",
   "delete_activity_confirm_title": "Confirmar Eliminación",
-  "delete_activity_confirm_text": "¿Seguro que quieres eliminar esta acción docente?",
+  "delete_activity_confirm_text": "¿Seguro que quieres eliminar esta acción docente? Esta acción también eliminará todas las notas del alumnado asociadas.",
   "import_students_alert": "Selecciona una clase y pega la lista del alumnado.",
   "generate_schedule_alert": "Por favor, rellena la hora de inicio, fin y la duración de la clase.",
   "add_override_alert": "Por favor, completa todos los campos de la sustitución.",

--- a/locales/eu.json
+++ b/locales/eu.json
@@ -260,7 +260,7 @@
   "class": "Klasea",
   "general": "Orokorra",
   "delete_activity_confirm_title": "Berretsi ezabatzea",
-  "delete_activity_confirm_text": "Ziur zaude irakaskuntza-ekintza hau ezabatu nahi duzula?",
+  "delete_activity_confirm_text": "Ziur zaude irakaskuntza-ekintza hau ezabatu nahi duzula? Ekintza honek lotutako ikasleen notak ere ezabatuko ditu.",
   "import_students_alert": "Hautatu klase bat eta itsatsi ikasleen zerrenda.",
   "generate_schedule_alert": "Mesedez, bete hasiera-ordua, amaiera-ordua eta klasearen iraupena.",
   "add_override_alert": "Mesedez, bete ordezkapenaren eremu guztiak.",

--- a/locales/gl.json
+++ b/locales/gl.json
@@ -260,7 +260,7 @@
   "class": "Clase",
   "general": "Xeral",
   "delete_activity_confirm_title": "Confirmar Eliminación",
-  "delete_activity_confirm_text": "Seguro que queres eliminar esta acción docente?",
+  "delete_activity_confirm_text": "Seguro que queres eliminar esta acción docente? Esta acción tamén eliminará todas as notas do alumnado asociadas.",
   "import_students_alert": "Selecciona unha clase e pega a lista do alumnado.",
   "generate_schedule_alert": "Por favor, enche a hora de inicio, fin e a duración da clase.",
   "add_override_alert": "Por favor, completa todos os campos da substitución.",

--- a/views.js
+++ b/views.js
@@ -1981,6 +1981,7 @@ export function renderSettingsView() {
                     <div class="flex items-center gap-2">
                         <button data-action="save-activity" data-id="${act.id}" class="text-green-600 hover:text-green-800"><i data-lucide="check" class="w-5 h-5"></i></button>
                         <button data-action="cancel-edit-activity" class="text-red-600 hover:text-red-800"><i data-lucide="x" class="w-5 h-5"></i></button>
+                        <button data-action="delete-activity" data-id="${act.id}" class="text-red-500 hover:text-red-700" title="${t('modal_delete')}" aria-label="${t('modal_delete')}"><i data-lucide="trash-2" class="w-5 h-5"></i></button>
                     </div>
                 </div>
                 <div class="mt-4 grid grid-cols-2 gap-4 text-sm">


### PR DESCRIPTION
## Summary
- add a delete icon button to the activity edit form
- ensure deleting an activity clears related schedules, entries, and learning activities
- update confirmation messaging to warn about associated student notes being removed

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e68e2bbd188324999dbc9d2daa6f81